### PR TITLE
Update log4j version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   ],
   "dependencies": {
-    "log4js": "~0.4.1"
+    "log4js": "~0.5.5"
   },
   "devDependencies": {
     "express": "~2.5.0"


### PR DESCRIPTION
In log4js 0.4.x the compress-buffer dependency is broken on sun os (ex: joyent, nodejitsu,etc).

Please update to 0.5.x, because in that, the compress-buffer dependency has been removed.
